### PR TITLE
feat: 관리자 페이지에서 배팅수정 ui 및 update Transactional 추가

### DIFF
--- a/src/main/java/com/outsider/masterofprediction/controller/AdminBettingUpdateController.java
+++ b/src/main/java/com/outsider/masterofprediction/controller/AdminBettingUpdateController.java
@@ -1,0 +1,64 @@
+package com.outsider.masterofprediction.controller;
+
+import com.outsider.masterofprediction.dto.TblSubjectDTO;
+import com.outsider.masterofprediction.dto.response.BettingAndAttachmentDTO;
+import com.outsider.masterofprediction.service.BettingService;
+import com.outsider.masterofprediction.service.BettingUpdateService;
+import com.outsider.masterofprediction.service.CategoryService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.sql.Date;
+
+@Controller
+public class AdminBettingUpdateController {
+    @Value("${file.imgUrl}")
+    private String imgUrl;
+    private final BettingService bettingService;
+    private final BettingUpdateService bettingUpdateService;
+    private final CategoryService categoryService;
+
+    @Autowired
+    public AdminBettingUpdateController(BettingUpdateService bettingUpdateService,
+                                        BettingService bettingService,
+                                        CategoryService categoryService) {
+        this.bettingUpdateService = bettingUpdateService;
+        this.bettingService = bettingService;
+        this.categoryService = categoryService;
+    }
+
+    @PostMapping("/admin-page/betting/update/{subjectNo}")
+    public String adminBettingUpdateSend(@ModelAttribute TblSubjectDTO tblSubjectDTO,
+                                         @RequestParam("attachmentFileAddress") MultipartFile file,
+                                         @RequestParam("deadline") Date date) {
+        try {
+            bettingUpdateService.update(tblSubjectDTO, file, date);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return "redirect:/admin-page/betting";
+    }
+
+    @GetMapping("/admin-page/betting/{subjectNo}")
+    public String adminNotificationUpdatePage(@PathVariable Long subjectNo, Model model) {
+        BettingAndAttachmentDTO betting = bettingService.getBettingAndAttachmentBySubjectNo(subjectNo);
+
+        betting.setAttachmentFileAddress(Paths.get(imgUrl).resolve(betting.getAttachmentFileAddress()).toString());
+
+
+
+        model.addAttribute("deadline", new Date(betting.getSubjectSettlementTimestamp().getTime()));
+        model.addAttribute("betting", betting);
+        model.addAttribute("categories", categoryService.findAll());
+
+        return "content/admin-page/betting/update";
+    }
+
+}
+

--- a/src/main/java/com/outsider/masterofprediction/service/BettingUpdateService.java
+++ b/src/main/java/com/outsider/masterofprediction/service/BettingUpdateService.java
@@ -1,0 +1,64 @@
+package com.outsider.masterofprediction.service;
+
+import com.outsider.masterofprediction.dto.TblAttachmentDTO;
+import com.outsider.masterofprediction.dto.TblSubjectDTO;
+import com.outsider.masterofprediction.dto.constatnt.StringConstants;
+import com.outsider.masterofprediction.mapper.AttachmentMapper;
+import com.outsider.masterofprediction.mapper.SubjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.sql.Date;
+import java.sql.Timestamp;
+
+@Service
+public class BettingUpdateService {
+    private final SubjectMapper subjectMapper;
+    private final AttachmentMapper attachmentMapper;
+    private final ProcessFileService processFileService;
+
+    @Autowired
+    public BettingUpdateService(SubjectMapper subjectMapper, AttachmentMapper attachmentMapper, ProcessFileService processFileService) {
+        this.subjectMapper = subjectMapper;
+        this.attachmentMapper = attachmentMapper;
+        this.processFileService = processFileService;
+    }
+
+    @Transactional
+    public void update(TblSubjectDTO tblSubjectDTO, MultipartFile file, Date date) throws IOException {
+
+        tblSubjectDTO.setSubjectSettlementTimestamp(new Timestamp(date.getTime()));
+        if (!file.isEmpty()){
+            TblAttachmentDTO tblAttachmentDTO = this.attachmentMapper.getAttachmentsBySubjectNo(tblSubjectDTO.getSubjectNo());
+            if (StringConstants.BASIC_IMAGE.equals(file.getOriginalFilename())
+                    || tblAttachmentDTO.getAttachmentFileAddress().equals(file.getOriginalFilename())){
+
+                subjectMapper.updateSubjectTitleAndCategoryAndSettlementTimestamp(tblSubjectDTO);
+                return;
+            }
+            // Transactional 상황을 고려해서 예외처리를 해야함
+            processFileService.execute(tblAttachmentDTO, file, attachmentMapper::updateAttachmentBySubjectNo);
+            subjectMapper.updateSubjectTitleAndCategoryAndSettlementTimestamp(tblSubjectDTO);
+        }
+    }
+
+    public void finish(String result, Long subjectNo){
+        String exitStatus = "종료";
+
+        if (UserSession.isAdmin() && (result.equals("Yes") || result.equals("No"))) {
+            TblSubjectDTO tblSubjectDTO = new TblSubjectDTO();
+            tblSubjectDTO.setSubjectNo(subjectNo);
+            tblSubjectDTO.setSubjectFinishResult(result);
+            tblSubjectDTO.setSubjectStatus(exitStatus);
+            
+            tblSubjectDTO.setSubjectFinishTimestamp(new Timestamp(System.currentTimeMillis()));
+            subjectMapper.updateSubjectResult(tblSubjectDTO);
+        //     포인트 정산 기능 추가
+        //     가입한 유저들의 주문내역을 가져와서
+        //      내가 건 금액 * (전체금액 / 내가 건 쪽 전체금액)
+        }
+    }
+}

--- a/src/main/resources/templates/content/admin-page/betting/update.html
+++ b/src/main/resources/templates/content/admin-page/betting/update.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <base th:href="@{/}">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&amp;display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/icon?family=Material+Symbols+Outlined" rel="stylesheet">
+
+    <script type="importmap">
+        {
+          "imports": {
+            "@material/web/": "https://esm.run/@material/web/"
+          }
+        }
+    </script>
+    <script type="module">
+        import "@material/web/all.js";
+        import {styles as typescaleStyles} from "@material/web/typography/md-typescale-styles.js";
+
+        document.adoptedStyleSheets.push(typescaleStyles.styleSheet);
+    </script>
+
+    <link rel="stylesheet" th:href="@{/css/admin-page/index.css}">
+    <link rel="stylesheet" th:href="@{/css/admin-page/notification/create.css}">
+    <link rel="stylesheet" th:href="@{/css/admin-page/betting/update.css}">
+    <link rel="stylesheet" th:href="@{/css/admin-page/betting/create.css}">
+    <link rel="stylesheet" th:href="@{/css/admin-page/font.css}">
+</head>
+<body>
+<div id="main">
+    <div id="sidebar" th:replace="content/admin-page/fragments/sidebar.html"></div>
+    <div id="wrapper">
+        <section id="response-section">
+            <div class="admin-main-head">
+                <h1 th:attr="data-id=${betting.subjectNo}">배팅상품 수정</h1>
+            </div>
+            <div class="admin-main-body-frame">
+                <form enctype="multipart/form-data" id="send-data" method="post"
+                      onsubmit="return validateForm()"
+                      th:action="@{/admin-page/betting/update/{id}(id=${betting.subjectNo})}"
+                      th:object="${betting}">
+                    <div class="admin-main-body">
+                        <div class="custom-file-input">
+                            <img class="img-tag" th:src="*{attachmentFileAddress}"/>
+                            <input class="file-input" name="attachmentFileAddress" onchange="previewImage(event)"
+                                   type="file"/>
+                        </div>
+                        <div class="betting-create-body">
+                            <div>
+                                <span>주제</span>
+                                <md-outlined-text-field class="body-value" id="notification-text-field"
+                                                        name="subjectTitle"
+                                                        th:attr="value=${betting.subjectTitle}"
+                                                        th:field="*{subjectTitle}"
+                                ></md-outlined-text-field>
+                            </div>
+
+                            <div>
+                                <span>카테고리</span>
+                                <select class="body-value" name="subjectCategoryNo"
+                                        th:value="${betting.subjectCategoryNo}">
+                                    <option th:each="category : ${categories}" th:text="${category.categoryName}"
+                                            th:value="${category.categoryNo}"></option>
+                                </select>
+                            </div>
+                            <div>
+                                <span>날짜</span>
+                                <input class="body-value" id="calendar" name="deadline" th:value="${deadline}"
+                                       type="date"/>
+                            </div>
+                        </div>
+                    </div>
+                </form>
+                <div id="button-frame">
+                    <md-filled-tonal-button class="create-button" form="send-data" type="submit">수정
+                    </md-filled-tonal-button>
+                    <form th:action="@{/admin-page/betting/result/{id}(id=${betting.getSubjectNo()})}">
+                        <md-filled-tonal-button class="create-button" type="submit">결과발표
+                        </md-filled-tonal-button>
+                    </form>
+                    <md-filled-tonal-button class="cansle-button" onclick="history.back()">취소</md-filled-tonal-button>
+                </div>
+            </div>
+        </section>
+    </div>
+</div>
+<!--이미지 태그 미리보기-->
+
+<script>
+    function previewImage(event) {
+        const file = event.target.files[0];
+        const reader = new FileReader();
+        reader.onloadend = function () {
+            document.getElementsByClassName("img-tag")[0].src = reader.result;
+        };
+        if (file) {
+            reader.readAsDataURL(file);
+        } else {
+            document.getElementsByClassName("img-tag")[0].src = "";
+        }
+    }
+</script>
+<script>
+    function validateForm() {
+        const textField = document.getElementById("notification-text-field");
+        const calender = document.getElementById("calendar");
+
+        if (
+            textField.value.trim("").length == 0 ||
+            calender.value.trim("").length == 0
+        ) {
+            return false;
+        }
+        // 등록 로직 추가
+        return true;
+        // window.location.href = "./";
+    }
+</script>
+</body>
+</html>


### PR DESCRIPTION
## 개요
관리자에서 배팅페이지의 특정 항목을 클릭 시 수정페이지로 넘어갈 수 있습니다

<!---- Resolves: #(Isuue Number) -->
Resolves: #33 

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  [Commit message convention 참고](https://github.com/mtvs-3rd-outsider/master-of-prediction/wiki/2.-%EC%BB%A8%EB%B2%A4%EC%85%98-%EB%B0%8F-%EA%B9%83-%ED%94%84%EB%A1%9C%EC%A0%9D%ED%8A%B8-%EA%B4%80%EB%A6%AC)
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
