### PR TITLE
fix: 헤더 css의 경로를 상대경로 -> 절대경로로 변경하였습니다

### DIFF
--- a/src/main/resources/templates/content/login-page/register.html
+++ b/src/main/resources/templates/content/login-page/register.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <div class="register-wrap"  th:fragment="content">
-    <link rel="stylesheet" th:href="@{css/login-page/login-page.css}">
+    <link rel="stylesheet" th:href="@{/css/login-page/login-page.css}">
     <div class="login-html">
         <div class="login-form">
             <form class="sign-up-htm" method="post" th:action="@{/register}">

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -3,8 +3,9 @@
       xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
 <body>
 <header id="DeskHeader" class="header" th:fragment="content">
-    <link rel="stylesheet" th:href="@{css/header/styles.css}"/>
-    <link rel="stylesheet" th:href="@{css/login-page/common.css}"/>
+    <link rel="stylesheet" th:href="@{/css/header/styles.css}"/>
+    <link rel="stylesheet" th:href="@{/css/login-page/common.css}"/>
+
     <div style="box-shadow: 0 2px 2px -2px gray;">
         <div style="display: flex;align-items: center;">
             <div class="logo" style="display: flex;">


### PR DESCRIPTION
## 개요
헤더 css 경로 변경
<!---- Resolves: #(Isuue Number) -->
Resolves:  #168 
## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  [Commit message convention 참고](https://github.com/mtvs-3rd-outsider/master-of-prediction/wiki/2.-%EC%BB%A8%EB%B2%A4%EC%85%98-%EB%B0%8F-%EA%B9%83-%ED%94%84%EB%A1%9C%EC%A0%9D%ED%8A%B8-%EA%B4%80%EB%A6%AC)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
